### PR TITLE
fix: update versionCode type to accept both number and string

### DIFF
--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -2566,7 +2566,10 @@
         },
         "versionCode": {
           "description": "版本号",
-          "type": "string"
+          "type": [
+            "number",
+            "string"
+          ]
         },
         "versionName": {
           "description": "版本名称，在云打包和生成 wgt 资源时使用",


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

我看到了之前有一个提交是允许 `manifest.json` 中的 `versionCode` 使用 String 和 Number 类型，但是在我使用 uni 插件的过程中，我发现这个并不起作用，它在 VSCode 中仍然只能使用 Number，并且会抛出一个 Warning。（如下截图所示）

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues

暂无。

### Additional context 额外上下文

<img width="1132" height="144" alt="image" src="https://github.com/user-attachments/assets/0f1ccbe3-1820-4f80-97a8-c2b7a38f20ea" />

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended configuration schema to support version codes in both numeric and string formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->